### PR TITLE
fix: comparison of version releases

### DIFF
--- a/src/Data/SemVer/Internal.hs
+++ b/src/Data/SemVer/Internal.hs
@@ -40,13 +40,21 @@ data Version = Version
     } deriving (Eq, Show)
 
 instance Ord Version where
-    compare a b = on compare versions a b <> on compare _versionRelease a b
+    compare a b = on compare versions a b <> on compareVersionRelease _versionRelease a b
       where
         versions Version{..} =
             [ _versionMajor
             , _versionMinor
             , _versionPatch
             ]
+
+-- | Compare version releases.
+--
+-- Note: Contrary to 'List's, @[] `compare` [xs]@ equals to @GT@
+compareVersionRelease :: [Identifier] -> [Identifier] -> Ordering
+[] `compareVersionRelease` _  = GT
+_  `compareVersionRelease` [] = LT
+a  `compareVersionRelease` b  = compare a b
 
 instance NFData Version where
     rnf Version{..} =


### PR DESCRIPTION
All version numbers being equal, an version with an empty pre-release
field is greater than a version with pre-release info.

hello,

From the Semantic Versioning Specification 2.0.0, it reads:

When major, minor, and patch are equal, a pre-release version has lower
precedence than a normal  version. Example: 1.0.0-alpha < 1.0.0.
(...)
A larger set of pre-release fields has a higher precedence than a
smaller set, if all of the preceding identifiers are equal. Example:
1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta <
1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.

The following test minimal program reproduces the problem:

```
{-# LANGUAGE OverloadedStrings #-}

import Data.SemVer
import Data.Text as T (unlines, Text)
import Data.Text.IO as T (putStrLn)
import Data.List (sort)
import Data.Either.Utils (forceEither)

main = do
    let textlist1 = [ "1.0.0-alpha"
                    , "1.0.0"
                    ]
    T.putStrLn $ sortByVerNum textlist1

    let textlist2 = [ "1.0.0-alpha"
                  , "1.0.0-alpha.1"
                  , "1.0.0-alpha.beta"
                  , "1.0.0-beta"
                  , "1.0.0-beta.2"
                  , "1.0.0-beta.11"
                  , "1.0.0-rc.1"
                  , "1.0.0"
                  ]
    T.putStrLn $ sortByVerNum textlist2

sortByVerNum :: [T.Text] -> T.Text
sortByVerNum = T.unlines . map toText . sort . map (forceEither . fromText)
```

best regards,
Damien
