### PR TITLE
Implement advanced constraint parsing for `Data.SemVer.Constraint.fromText`

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,10 +1,10 @@
 cradle:
   cabal:
-    - path: "src"
+    - path: "lib"
       component: "lib:semver"
 
     - path: "bench/Main.hs"
-      component: "semver:bench:semver-bench"
+      component: "semver:bench:bench"
 
     - path: "test"
-      component: "semver:test:semver-test"
+      component: "semver:test:tests"

--- a/lib/Data/SemVer/Constraint.hs
+++ b/lib/Data/SemVer/Constraint.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- |
 -- Module      : Data.SemVer.Constraint
@@ -26,13 +27,17 @@ module Data.SemVer.Constraint
   )
 where
 
-import Control.Applicative ((<|>))
+import Control.Applicative (many, optional, (<**>), (<|>))
+import qualified Control.Monad as Monad
 import Data.Attoparsec.Text (Parser)
 import qualified Data.Attoparsec.Text as Parsec
+import qualified Data.List as List
+import Data.Maybe (fromMaybe)
+import qualified Data.SemVer as SemVer
 import qualified Data.SemVer.Delimited as Delimited
 import Data.SemVer.Internal
-import qualified Data.SemVer as SemVer
 import Data.Text (Text)
+import GHC.Stack (HasCallStack)
 
 data Constraint
   = CAny
@@ -95,9 +100,6 @@ satisfies version constraint =
       CAnd a b -> go v a && go v b
       COr a b -> go v a || go v b
 
--- | Parsing function to create a 'Constraint' from 'Text' according to the rules specified
--- here: https://github.com/npm/node-semver#ranges
-
 toText :: Constraint -> Text
 toText c = case c of
   CAny -> "*"
@@ -109,43 +111,203 @@ toText c = case c of
   CAnd a b -> toText a <> " " <> toText b
   COr a b -> toText a <> " || " <> toText b
 
+-- | Parsing function to create a 'Constraint' from 'Text' according to the rules specified
+-- here: https://github.com/npm/node-semver#ranges
 --
--- Advanced syntax is not yet supported.
+-- Advanced syntax is supported with the following conservative caveats:
+-- * Wildcards can't appear in the middle of a fully specified version number.
+-- That is: @1.x.x@ is valid as is @1.x@ but @1.x.1@ isn't.
+-- * Prereleases and metadata information aren't allowed together with
+-- wildcards. To use them you must specify the entire version number.
+-- * The constraint is required to contain at least one part. That is @""@ is
+-- not a valid constraint. Instead use @"*"@, @"X"@, or @"x"@ all of which
+-- desugar to @CAny@
+-- * Combinations of @~@ and @^@ with comparison operators (@>@, @<@, @<=@,
+-- @>=@, @=@) isn't supported because their semantics is ill-defined; these
+-- will fail to parse
 fromText :: Text -> Either String Constraint
 fromText = Parsec.parseOnly parser
 
 parser :: Parser Constraint
 parser = parserWith Delimited.semantic
 
-parserWith :: Delimiters -> Parser Constraint
-parserWith delims =
-  Parsec.choice ((<* Parsec.endOfInput) <$> [primP, andP, orP])
-  where
-    versionP =
-      Delimited.parser delims False
+-- | Partial versions found in ranges that may not contain every part.
+-- Invariant:
+-- * if major is Nothing then so are minor, patch, release, and meta
+-- * likewise if minor is Nothing then so are patch, release and meta
+data PartialVersion = PartialVersion
+  { _partialVersionMajor :: Maybe Int,
+    _partialVersionMinor :: Maybe Int,
+    _partialVersionPatch :: Maybe Int,
+    _partialVersionRelease :: [Identifier],
+    _partialVersionMeta :: [Identifier]
+  }
+  deriving (Show)
 
-    primP =
-      Parsec.choice
-        [ Parsec.char '*' *> pure CAny,
-          Parsec.char '<' *> (CLt <$> versionP),
-          Parsec.string "<=" *> (CLtEq <$> versionP),
-          Parsec.char '>' *> (CGt <$> versionP),
-          Parsec.string ">=" *> (CGtEq <$> versionP),
-          CEq <$> ((Parsec.option '=' (Parsec.char '=')) *> versionP)
-        ]
+smallestMatchingVersion :: PartialVersion -> Version
+smallestMatchingVersion PartialVersion {..} =
+  Version
+    (fromMaybe 0 _partialVersionMajor)
+    (fromMaybe 0 _partialVersionMinor)
+    (fromMaybe 0 _partialVersionPatch)
+    _partialVersionRelease
+    _partialVersionMeta
 
-    andP =
+-- | Get the next verison doesn't overlap the partial
+-- Invariant: PartialVersion has major version of Just; there isn't a version
+-- that doesn't overlap with @PartialVersion Nothing Nothing Nothing [] []@
+nextNonMatchingVersion :: HasCallStack => PartialVersion -> Version
+nextNonMatchingVersion PartialVersion {..} =
+  case (_partialVersionMajor, _partialVersionMinor, _partialVersionPatch) of
+    (Nothing, _, _) ->
+      error "broken invariant: _partialVersionMajor must be Just"
+    (Just m, Nothing, _) ->
+      Version (m + 1) 0 0 [] []
+    (Just m, Just n, Nothing) ->
+      Version m (n + 1) 0 [] []
+    (Just n, Just m, Just o) ->
+      Version m n (o + 1) [] []
+
+strictlyLessThan :: PartialVersion -> Constraint
+strictlyLessThan = CLt . smallestMatchingVersion
+
+lessThanOrEqual :: PartialVersion -> Constraint
+lessThanOrEqual v@PartialVersion {..} =
+  case (_partialVersionMajor, _partialVersionMinor, _partialVersionPatch) of
+    (Nothing, Nothing, Nothing) -> CAny
+    (Just major, Just minor, Just patch) ->
+      CLtEq $ Version major minor patch _partialVersionRelease _partialVersionMeta
+    _ -> CLt $ nextNonMatchingVersion v
+
+strictlyGreaterThan :: PartialVersion -> Constraint
+strictlyGreaterThan v@PartialVersion {..} =
+  case (_partialVersionMajor, _partialVersionMinor, _partialVersionPatch) of
+    (Nothing, Nothing, Nothing) -> CLt $ Version 0 0 0 [] []
+    (Just major, Just minor, Just patch) ->
+      CGt $ Version major minor patch _partialVersionRelease _partialVersionMeta
+    _ -> CGtEq $ nextNonMatchingVersion v
+
+greaterThanOrEqual :: PartialVersion -> Constraint
+greaterThanOrEqual = CGtEq . smallestMatchingVersion
+
+rangeBetweenPartialVersions :: PartialVersion -> PartialVersion -> Constraint
+rangeBetweenPartialVersions minVersion maxVersion =
+  CAnd (greaterThanOrEqual minVersion) (lessThanOrEqual maxVersion)
+
+equalTo :: PartialVersion -> Constraint
+equalTo v@PartialVersion {..} =
+  case (_partialVersionMajor, _partialVersionMinor, _partialVersionPatch) of
+    (Nothing, _, _) -> CAny
+    (Just major, Just minor, Just patch) ->
+      CEq $ Version major minor patch _partialVersionRelease _partialVersionMeta
+    _ -> rangeBetweenPartialVersions v v
+
+tildedVersionRange :: PartialVersion -> Constraint
+tildedVersionRange v@PartialVersion {..} = case _partialVersionMinor of
+  Just _ ->
+    rangeBetweenPartialVersions
+      v
+      (PartialVersion _partialVersionMajor _partialVersionMinor Nothing [] [])
+  Nothing ->
+    equalTo $ PartialVersion _partialVersionMajor Nothing Nothing [] []
+
+caretedVersionRange :: PartialVersion -> Constraint
+caretedVersionRange v@PartialVersion {..} =
+  case (_partialVersionMajor, _partialVersionMinor, _partialVersionPatch) of
+    (Just 0, Just 0, Just n) ->
+      -- To properly handle release versions we need to manually construct
+      -- this range so that releases are included. With
+      -- rangeBetweenPartialVersions we would generate @>=0.0.n-alpha.1 <=0.0.n@
+      -- which would not match @0.0.n-alpha.2@ for example, but here we construct
+      -- @>=0.0.n-alpha.1 <0.0.(n + 1)@ which does match @0.0.n-alpha.2@
+      -- This isn't a problem for the other cases because we already generate
+      -- something with @<@ for the upper bound.
       CAnd
-        <$> primP
-        <*> ( Parsec.skipSpace
-                *> (andP <|> primP)
-            )
+        (greaterThanOrEqual v)
+        (CLt (Version 0 0 (n + 1) [] []))
+    (Just 0, Just 0, _) ->
+      rangeBetweenPartialVersions
+        v
+        (PartialVersion _partialVersionMajor _partialVersionMinor _partialVersionPatch [] [])
+    (Just 0, _, _) ->
+      rangeBetweenPartialVersions
+        v
+        (PartialVersion _partialVersionMajor _partialVersionMinor Nothing [] [])
+    _ ->
+      rangeBetweenPartialVersions
+        v
+        (PartialVersion _partialVersionMajor Nothing Nothing [] [])
 
-    orP =
-      COr
-        <$> (andP <|> primP)
-        <*> ( Parsec.skipSpace
-                *> Parsec.string "||"
-                *> Parsec.skipSpace
-                *> (orP <|> andP <|> primP)
+parserWith :: Delimiters -> Parser Constraint
+parserWith Delimiters {..} = rangeSet <* Parsec.endOfInput
+  where
+    -- implementation of these follows fairly closely to the Range Grammar
+    -- specified here: https://github.com/npm/node-semver#range-grammar
+    rangeSet = List.foldl1' COr <$> range `Parsec.sepBy1'` logicalOr
+    logicalOr = Parsec.skipSpace *> Parsec.string "||" *> Parsec.skipSpace
+    range =
+      (primitive <**> moreSimples)
+        <|> (tilde <**> moreSimples)
+        <|> (caret <**> moreSimples)
+        <|> ( (partial <* Parsec.char ' ' <* Parsec.skipSpace)
+                <**> (hyphenEnd <|> fmap (. equalTo) moreSimples)
             )
+        <|> (equalTo <$> partial)
+    moreSimples :: Parser (Constraint -> Constraint)
+    moreSimples =
+      flip (\first -> List.foldl1' CAnd . (first :))
+        <$> Parsec.many' (Parsec.skipSpace *> simple)
+    hyphenEnd :: Parser (PartialVersion -> Constraint)
+    hyphenEnd =
+      flip rangeBetweenPartialVersions
+        <$> (Parsec.string "- " *> Parsec.skipSpace *> partial)
+    simple :: Parser Constraint
+    simple = primitive <|> tilde <|> caret <|> (equalTo <$> partial)
+    primitive =
+      Parsec.choice
+        [ Parsec.char '<' *> Parsec.skipSpace *> (strictlyLessThan <$> partial),
+          Parsec.string "<=" *> Parsec.skipSpace *> (lessThanOrEqual <$> partial),
+          Parsec.char '>' *> Parsec.skipSpace *> (strictlyGreaterThan <$> partial),
+          Parsec.string ">=" *> Parsec.skipSpace *> (greaterThanOrEqual <$> partial),
+          Parsec.char '=' *> Parsec.skipSpace *> (equalTo <$> partial)
+        ]
+    tilde = Parsec.char '~' *> Parsec.skipSpace *> (tildedVersionRange <$> partial)
+    caret = Parsec.char '^' *> Parsec.skipSpace *> (caretedVersionRange <$> partial)
+    versionPart :: Parser (Maybe Int)
+    versionPart =
+      (Nothing <$ Parsec.satisfy (Parsec.inClass "xX*"))
+        <|> (Just <$> nonNegative)
+    partial :: Parser PartialVersion
+    partial = do
+      major <- versionPart
+      minor <- optional (Parsec.char _delimMinor *> versionPart)
+      patch <- optional (Parsec.char _delimPatch *> versionPart)
+      release <-
+        Parsec.option [] (Parsec.try (Parsec.char _delimRelease) *> identifiers)
+      meta <-
+        Parsec.option [] (Parsec.try (Parsec.char _delimMeta) *> identifiers)
+      case (major, minor, patch, release, meta) of
+        (_, _, Nothing, _ : _, _) ->
+          fail "can't supply prerelease without supplying patch"
+        (_, _, Just Nothing, _ : _, _) ->
+          fail "can't supply prerelease without supplying explicit patch"
+        (_, _, Nothing, _, _ : _) ->
+          fail "can't supply metadata without supplying patch"
+        (_, _, Just Nothing, _, _ : _) ->
+          fail "can't supply metadata without supplying explicit patch"
+        (_, Nothing, Just _, _, _) ->
+          fail "can't supply patch without supplying minor"
+        (_, Just Nothing, Just (Just _), _, _) ->
+          fail "can't supply specific patch after supplying wildcard for minor"
+        (Nothing, Just (Just _), _, _, _) ->
+          fail "can't supply specific minor after supplying wildcard for major"
+        (Nothing, Nothing, Nothing, _, _) ->
+          pure $ PartialVersion Nothing Nothing Nothing release meta
+        (_, Nothing, Nothing, _, _) ->
+          pure $ PartialVersion major Nothing Nothing release meta
+        (_, Just minor', Nothing, _, _) ->
+          pure $ PartialVersion major minor' Nothing release meta
+        (_, Just minor', Just patch', _, _) ->
+          pure $ PartialVersion major minor' patch' release meta
+    identifiers :: Parser [Identifier]
+    identifiers = many (identifierParser $ Monad.void (Parsec.char _delimIdent))


### PR DESCRIPTION
There are a few edge cases where implementing the exact behavior of `node-semver` felt too gross to do, and I think that the edge cases are justifiable to not support. All of these cases are conservative however, that is there isn't any case that is parsed and interpreted differently than node-semver, there are merely cases where this implementation fails to parse something that node-semver does parse into a constraint, so it should be possible to add them in a non-breaking way later if that is desired.

<details>
<summary>Details on the ways that the implementation deviates from node-semver</summary>
You can find a repl.it that uses the node-semver implementation to verify some of these points here: https://replit.com/@lehmacdj/SmartFrugalScreencast
* Wildcards can't appear in the middle of a fully specified version number.
That is: @1.x.x@ is valid as is @1.x@ but @1.x.1@ isn't.
   - `1.x.1` is interpreted as having the same meaning as `1.x` in the node-semver implementation so this doesn't loose strength, and arguably such constraints are a bad idea anyways
* Prereleases and metadata information aren't allowed together with
wildcards. To use them you must specify the entire version number.
   - Similar to the previous point, node-semver ignores prereleases and metadata when used with wildcards.
* The constraint is required to contain at least one part. That is @""@ is
not a valid constraint. Instead use @"*"@, @"X"@, or @"x"@ all of which
desugar to @CAny@
   - Interactions of this rule for the parser makes very weird things parsable. node-semver allows parsing `||` as a constraint meaning `* || *` which feels very weird for example. Also without adding cruft the parser to avoid edge cases comparison operators would be parseable on their own so that `>=` would be equivalent to `>=*` i.e. `CAny`.
* Combinations of @~@ and @^@ with comparison operators (@>@, @<@, @<=@,
@>=@, @=@) isn't supported because their semantics is ill-defined; these
will fail to parse
   - Although there were a few test cases provided in node-semver they seemed confusing and would also be fairly hard to implement.
</details>


The implementation is based on the [grammar provided in npm/node-semver](https://github.com/npm/node-semver#range-grammar), with deviations to make the parser compatible with Attoparsec, and to reuse some existing infrastructure. Regrettably I ended up essentially reimplementing the parser for versions but this was necessary for implementing partial verisons (e.g. `1.2`) and versions containing wildcards (e.g. `1.2.x`). The parser converts to the pre-existing constraint language as it parses in one fell swoop, without converting to an intermediate data-structure in between.

Tests are pulled from node-semver: `https://github.com/npm/node-semver/blob/master/test/fixtures/range-parse.js
- Some of these changes were just because this implementation doesn't normalize constraints. For example: `* || *` is left as is instead of turning it into just the constraint `*`. For a slightly more sophisticated example `>x 2.x || * || <x` parses to a constraint `<0.0.0 >=2.0.0 <3.0.0 || * || <0.0.0` as opposed to `*`. In general, I checked that the result of my implementation was equivalent to the node-semver expected test result and if it was, changed the test to the output produced by this implementation.
- The node-semver implementation pervasively appends `-0` to the end of its generated constraints. While this is more technically correct because `1.0.0-0` is technically a prerelease of `1.0.0`, it doesn't matter extensionally because `1.0.0-0` doesn't satisfy the constraint `<1.0.0` so dropping it doesn't affect the semantics of the result. I also had to remove these suffixes from the constraints generated this implementation because it doesn't generate them.
- It might be worth comparing the tests in node-semver with the ones that I extracted to make sure that I didn't slip up in making these small changes that I did.
- Existing tests for constraints all still pass, and the actual constraint satisfaction thing isn't affected because the constraint type is identical.