### PR TITLE
Add a quasi-quoter for 'Version'

### DIFF
--- a/lib/Data/SemVer/Internal.hs
+++ b/lib/Data/SemVer/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -26,6 +28,8 @@ import qualified Data.Attoparsec.Text as Parsec
 import qualified Data.Function as Function
 import Data.Hashable (Hashable)
 import qualified Data.List as List
+import qualified Language.Haskell.TH.Syntax as TH
+import Data.Data (Data)
 import qualified Data.Monoid as Monoid
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -46,7 +50,7 @@ data Version = Version
     _versionRelease :: [Identifier],
     _versionMeta :: [Identifier]
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Data, TH.Lift)
 
 instance Ord Version where
   compare a b = Function.on compare versions a b <> release
@@ -77,7 +81,7 @@ instance Hashable Version
 data Identifier
   = INum !Int
   | IText !Text
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Show, Generic, Data, TH.Lift)
 
 instance Ord Identifier where
   compare a b = case (a, b) of

--- a/lib/Data/SemVer/QQ.hs
+++ b/lib/Data/SemVer/QQ.hs
@@ -1,0 +1,45 @@
+-- |
+-- Module      : Data.SemVer.QQ
+-- Copyright   : (c) 2022 Brendan Hay <brendan.g.hay@gmail.com>
+-- License     : This Source Code Form is subject to the terms of
+--               the Mozilla Public License, v. 2.0.
+--               A copy of the MPL can be found in the LICENSE file or
+--               you can obtain it at http://mozilla.org/MPL/2.0/.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+-- Quasi-quotation for defining 'Version' constants.
+module Data.SemVer.QQ
+  ( version
+  )
+where
+
+import qualified Data.SemVer as Base
+import qualified Data.Text as Text
+import Control.Monad ((<=<))
+import Language.Haskell.TH.Quote
+import Language.Haskell.TH.Syntax
+
+-- | Build a 'Version'.
+--
+-- >>> import Data.SemVer (toText)
+-- >>> import qualified Data.SemVer.QQ as Q
+-- >>> toText [Q.version| 0.1.23-alpha |]
+-- "0.1.23-alpha"
+--
+-- >>> toText [Q.version| 0.1.a |]
+-- • Invalid version format
+-- • In the quasi-quotation: [Q.version|0.1.a|]
+version :: QuasiQuoter
+version = QuasiQuoter
+  { quoteExp = lift <=< parseVersion
+  , quotePat = dataToPatQ (const Nothing) <=< parseVersion
+  , quoteType = \_ -> fail "Cannot be used as a type"
+  , quoteDec = \_ -> fail "Cannot be used as a declaration"
+  }
+  where
+    parseVersion str =
+      case Base.fromText (Text.strip $ Text.pack str) of
+        Right x -> pure x
+        Left _ -> fail "Invalid version format"

--- a/semver.cabal
+++ b/semver.cabal
@@ -41,12 +41,14 @@ library
     Data.SemVer.Constraint
     Data.SemVer.Delimited
     Data.SemVer.Internal
+    Data.SemVer.QQ
 
   build-depends:
-    , attoparsec  >=0.10
-    , deepseq     >=1.4
-    , hashable    >=1.2.5
-    , text        >=0.11
+    , attoparsec       >=0.10
+    , deepseq          >=1.4
+    , hashable         >=1.2.5
+    , text             >=0.11
+    , template-haskell >=2.11.0.0
 
 benchmark bench
   import:         base

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 -- |
 -- Module      : Main
@@ -15,6 +16,7 @@ module Main (main) where
 import qualified Data.List as List
 import Data.SemVer (Version)
 import qualified Data.SemVer as SemVer
+import qualified Data.SemVer.QQ as SemVer.QQ
 import Data.SemVer.Constraint (Constraint, satisfies)
 import qualified Data.SemVer.Constraint as SemVer.Constraint
 import Data.Text (Text)
@@ -249,6 +251,22 @@ main =
                   true (sv "1.0.0-beta" `satisfies` sc ">=1.0.0-alpha"),
                 testCase "regular versions can satisfy prerelease constraints" $
                   true (sv "3.0.0" `satisfies` sc ">=2.0.0-alpha")
+              ]
+          ],
+        testGroup
+          "quasi-quoter"
+          [ testGroup
+              "as expression"
+              [ testCase "can define a valid version" $
+                  [SemVer.QQ.version|1.0.0-alpha|] @?= sv100alpha
+              , testCase "can surround version with spaces" $
+                  [SemVer.QQ.version| 1.0.0 |] @?= sv100
+              ]
+          , testGroup
+              "as pattern"
+              [ testCase "can use at pattern position" $
+                  let isInit v = case v of [SemVer.QQ.version| 0.0.0 |] -> True; _ -> False
+                  in map isInit [sv000, sv100] @?= [True, False]
               ]
           ]
       ]


### PR DESCRIPTION
Resolves #16

This lets us define version constants in a safe manner directly in the code or in dedicated files (the latter with the help of [quoteFile](https://hackage.haskell.org/package/template-haskell-2.19.0.0/docs/Language-Haskell-TH-Quote.html#v:quoteFile))

Potential concerns:
* `template-haskell` is quite a heavy dependency, especially compared to the current minimalistic dependencies set.
